### PR TITLE
Update iconfont_data.dart

### DIFF
--- a/lib/src/iconfont_data.dart
+++ b/lib/src/iconfont_data.dart
@@ -79,7 +79,7 @@ class IconFontGlyph {
     iconId = json['icon_id'];
     fontClass = json['font_class'];
     unicode = json['unicode'];
-    unicodeDecimal = json['unicode_decimal'];
+    unicodeDecimal = json['unicode_decimal']?.toString();
     name = json['name'];
   }
 


### PR DESCRIPTION
阿里图标库现在的iconfont.json文件中unicode_decimal字段目前为int类型